### PR TITLE
fix: Compression processing is inconsistent with heatshrink algorithm.

### DIFF
--- a/heatshrinkpy/core/encoder.py
+++ b/heatshrinkpy/core/encoder.py
@@ -253,7 +253,7 @@ class Writer:
                 pos = self._search_index[pos]
                 continue
 
-            for ml in range(1, maxlen):
+            for ml in range(1, maxlen + 1):
                 if self._buffer[pos + ml] != self._buffer[end + ml]:
                     break
 


### PR DESCRIPTION
After compressing the same files at the same time with the [heatshrink algorithm](https://github.com/atomicobject/heatshrink), different results are produced. After searching the problem, the use of the for loop in C and python is different, and the need to synchronize C processing in python can get the same result.
C code processing:
```
        for (len = 1; len < maxlen; len++) {
            if (pospoint[len] != needlepoint[len]) break;
        }
```
In the same case, _len_ can be equal to _maxlen_ in C, but _ml_ cannot be equal to _maxlen_ in python.

If this problem does exist, hopefully my changes will fix it and a new version will be released.