### PR TITLE
fix: Compression error if size > 2^window_sz2 and all 0.

### DIFF
--- a/heatshrinkpy/core/encoder.py
+++ b/heatshrinkpy/core/encoder.py
@@ -254,7 +254,7 @@ class Writer:
                 continue
 
             for ml in range(1, maxlen + 1):
-                if self._buffer[pos + ml] != self._buffer[end + ml]:
+                if ml == maxlen or self._buffer[pos + ml] != self._buffer[end + ml]:
                     break
 
             if ml > match_maxlen:


### PR DESCRIPTION
Compare these two pieces of C and python code differences.
```
        for (len = 1; len < maxlen; len++) {
            if (pospoint[len] != needlepoint[len]) break;
        }
```
```
            for ml in range(1, maxlen + 1):
                if self._buffer[pos + ml] != self._buffer[end + ml]:
                    break
```
In the second code, when _ml == maxlen_, _maxlen_ participates in the computation. In the same case, the first piece of code does not participate in the calculation. As a result, the boundary can be crossed, resulting in an exception.